### PR TITLE
remove `console.log` of compiler settings

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,6 @@ task(TASK_COMPILE).setAction(async function(args, hre, runSuper) {
   for (const compiler of hre.config.solidity.compilers) {
     compiler.settings.outputSelection["*"]["*"].push("storageLayout");
   }
-  console.log(hre.config.solidity.compilers);
   await runSuper(args);
 });
 


### PR DESCRIPTION
This PR removes a `console.log` of compiler settings in `TASK_COMPILE`.